### PR TITLE
feat: hydration with zoneless. Having to use HTTP Client

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1,4 +1,6 @@
 import '@angular/compiler';
+import './src/mock-zone'
+
 
 import { Elysia, t } from 'elysia';
 import { join } from 'path';
@@ -34,7 +36,7 @@ const app = new Elysia()
   })
   .group('/api', (api) => {
     return api
-      .get('/id/:id', ({ params: { id } }) => `Post with id: ${id}`)
+      .get('/id/:id', ({ params: { id } }) => ({ data: `Post with id: ${id}` }))
       .get('/example', () => `just an example`)
       .post('/form', ({ body }) => body, {
         body: t.Object({

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -9,11 +9,12 @@ import {
   withHttpTransferCacheOptions,
 } from '@angular/platform-browser';
 import { routes } from './app.routes';
+import { provideHttpClient, withFetch } from '@angular/common/http';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZonelessChangeDetection(),
-    // provideHttpClient(withFetch()),
+    provideHttpClient(withFetch()),
     provideRouter(routes, withComponentInputBinding()),
     provideClientHydration(
       withHttpTransferCacheOptions({
@@ -22,3 +23,4 @@ export const appConfig: ApplicationConfig = {
     ),
   ],
 };
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,34 +1,7 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { AppComponent } from './app/app.component';
 import { appConfig } from './app/app.config';
-
-type Zone = {
-  current: {
-    get(key: string): boolean | undefined;
-    run<T>(fn: (...args: any[]) => T, applyThis?: any, applyArgs?: any): T;
-  };
-  run<T>(fn: (...args: any[]) => T, applyThis?: any, applyArgs?: any): T;
-};
-declare var Zone: Zone;
-declare module globalThis {
-  let Zone: Zone;
-}
-
-if (typeof Zone === 'undefined') {
-  const mockZone = {
-    current: {
-      get: (key: string): boolean | undefined =>
-        key === 'isAngularZone' ? true : undefined,
-      run<T>(fn: (...args: any[]) => T, applyThis?: any, applyArgs?: any): T {
-        return fn.apply(applyThis, applyArgs);
-      },
-    },
-    run<T>(fn: (...args: any[]) => T, applyThis?: any, applyArgs?: any): T {
-      return fn.apply(applyThis, applyArgs);
-    },
-  };
-  globalThis.Zone = mockZone;
-}
+import './mock-zone';
 
 bootstrapApplication(AppComponent, appConfig).catch((err) =>
   console.error(err)

--- a/src/mock-zone.ts
+++ b/src/mock-zone.ts
@@ -1,0 +1,15 @@
+if (typeof (globalThis as any).Zone === 'undefined') {
+    const mockZone = {
+      current: {
+        get: (key: string): boolean | undefined =>
+          key === 'isAngularZone' ? true : undefined,
+        run<T>(fn: (...args: any[]) => T, applyThis?: any, applyArgs?: any): T {
+          return fn.apply(applyThis, applyArgs);
+        },
+      },
+      run<T>(fn: (...args: any[]) => T, applyThis?: any, applyArgs?: any): T {
+        return fn.apply(applyThis, applyArgs);
+      },
+    };
+    (globalThis as any).Zone = mockZone;
+  }


### PR DESCRIPTION
follow up PR to make the httpclient eden type safe. This PR is just to get hydration working, with no errors and in zoneless



before:
![image](https://github.com/sp90/treaty/assets/2092344/a5b95590-5e7c-4ad8-828e-ad89cf22092c)
![image](https://github.com/sp90/treaty/assets/2092344/dd1958e2-7f07-4783-999d-f68735f81cc5)


After:
![image](https://github.com/sp90/treaty/assets/2092344/05ea17fb-26b9-44e3-ba16-1ac384eea1aa)
![image](https://github.com/sp90/treaty/assets/2092344/bc7fc62e-f253-400f-a5fd-adb5c95b1b10)


You will see in the before it makes the API call on the client and also not in the state so its not trying to be called on the server. Compared to the after the API isn't called and state is transferred 